### PR TITLE
Do not use same mac from hardif for bat0 as well

### DIFF
--- a/host_vars/gw01.ffbsee.net.yml
+++ b/host_vars/gw01.ffbsee.net.yml
@@ -31,6 +31,7 @@ ipv6_radv_address: '{{ ipv6_prefix }}{{ ipv6_radv_suffix }}'
 ipv6_radv_prefix: '{{ ipv6_prefix }}:/64'
 
 # batman - used addresses
+bat0_mac_address: '82:77:f7:59:2f:f4'
 ipv4_mesh_address: '10.15.224.1' 
 ipv6_suffix: ':1'
 wan_base_interface: 'enp2s0'

--- a/host_vars/gw03.ffbsee.net.yml
+++ b/host_vars/gw03.ffbsee.net.yml
@@ -2,6 +2,7 @@
 hostname: 'gw03.ffbsee.net'
 
 ipv4_mesh_address: '10.15.224.3'
+bat0_mac_address: '26:47:2f:02:f1:45'
 
 ipv6_suffix: ':3'
 ipv6_radv_suffix: ':3'

--- a/host_vars/gw04.ffbsee.net.yml
+++ b/host_vars/gw04.ffbsee.net.yml
@@ -2,6 +2,7 @@
 hostname: 'gw04.ffbsee.net'
 
 ipv4_mesh_address: '10.15.224.4'
+bat0_mac_address: '9a:93:7e:b2:ad:75'
 
 ipv6_suffix: ':4'
 ipv6_radv_suffix: ':1'

--- a/host_vars/map.ffbsee.net.yml
+++ b/host_vars/map.ffbsee.net.yml
@@ -2,6 +2,7 @@
 hostname: 'map.ffbsee.net'
 
 ipv4_mesh_address: '10.15.224.6'
+bat0_mac_address: '86:00:00:2c:de:52'
 
 ipv6_suffix: ':6'
 ipv6_radv_suffix: ':1'

--- a/templates/freifunk-files/update.sh
+++ b/templates/freifunk-files/update.sh
@@ -6,7 +6,7 @@
 #   and all systems are running
 
 # Server address
-mac_addr="{{ mac_address }}"
+mac_addr="{{ bat0_mac_address }}"
 mesh_ipv6_addr="{{ mesh_ipv6_address }}"
 mesh_ipv6_extra_addr="{{ mesh_ipv6_extra_addr }}"
 ff_prefix="{{ ipv6_prefix }}:"


### PR DESCRIPTION
it's generally a bad idea to use same mac adress twice.
here  the mac from the real ethernet interface was used again for bat0
Here we introduce new 'rolled' mac addresses for batman interface on each host.